### PR TITLE
Failed attempt to modify tunnel data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require github.com/joho/godotenv v1.5.1
 
 require github.com/mattn/go-sqlite3 v1.14.24
 
+require golang.org/x/net v0.33.0
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,7 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/proxy/ad.go
+++ b/internal/proxy/ad.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"bytes"
+	"log"
+
+	"golang.org/x/net/html"
+)
+
+func removeAds(body []byte) ([]byte, error) {
+	log.Printf("Modifying HTML to remove iframe and ins tags...")
+
+	rootNode, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var traverse func(*html.Node)
+	traverse = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "iframe":
+				log.Print("Gottem iframe")
+				n.Parent.RemoveChild(n)
+			case "ins":
+				log.Print("ins, gottem!")
+				n.Parent.RemoveChild(n)
+			}
+		}
+
+		for c := n.FirstChild; c != nil; {
+			next := c.NextSibling
+			traverse(c)
+			c = next
+		}
+	}
+
+	traverse(rootNode)
+
+	var buf bytes.Buffer
+	err = html.Render(&buf, rootNode)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/proxy/connect.go
+++ b/internal/proxy/connect.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -62,13 +64,61 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			transferCompleted <- struct{}{}
 		}()
 
-		written, err := io.Copy(dst, src)
-		if err != nil && err != io.EOF {
-			transferErrors <- fmt.Errorf("%s transfer error after %d bytes: %v", name, written, err)
-			return
-		}
+		reader := bufio.NewReader(src)
+		buffer := make([]byte, 32*1024)
 
-		log.Printf("%s transfer completed successfully: %d bytes", name, written)
+		for {
+			n, err := reader.Read(buffer)
+			if err != nil {
+				if err != io.EOF {
+					transferErrors <- fmt.Errorf("%s transfer error: %v", name, err)
+				}
+				return
+			}
+
+			data := buffer[:n]
+			if name == "Dest->Client" {
+
+				if bytes.Contains(data, []byte("HTTP/1.")) &&
+					bytes.Contains(data, []byte("Content-Type: text/html")) {
+
+					/*
+						we will never reach here!
+						the data is scrambled. I tried utf8 decoding and gzip decompression, but none worked!
+						I think as the 'data' inside this CONNECT tunnel is TLS encrypted, above string comparion fails.
+					*/
+
+					parts := bytes.Split(data, []byte("\r\n\r\n"))
+					if len(parts) > 1 {
+						headers := parts[0]
+						body := bytes.Join(parts[1:], []byte("\r\n\r\n"))
+						if newBody, err := removeAds(body); err == nil {
+
+							log.Print("new: ", newBody)
+
+							headerLines := bytes.Split(headers, []byte("\r\n"))
+							for i, line := range headerLines {
+								if bytes.HasPrefix(bytes.ToLower(line), []byte("content-length:")) {
+									headerLines[i] = []byte(fmt.Sprintf("Content-Length: %d", len(newBody)))
+									break
+								}
+							}
+							headers = bytes.Join(headerLines, []byte("\r\n"))
+
+							data = append(headers, []byte("\r\n\r\n")...)
+							data = append(data, newBody...)
+						}
+					}
+				}
+			}
+
+			_, err = dst.Write(data)
+			// log.Printf("%s transfer completed successfully: %d bytes", name, written)
+			if err != nil {
+				transferErrors <- fmt.Errorf("%s write error: %v", name, err)
+				return
+			}
+		}
 	}
 
 	// Starting transfers


### PR DESCRIPTION
The data is scrambled. I tried UTF8 decoding and GZIP decompression, but none worked!
I think as the data inside the CONNECT tunnel is TLS encrypted, we fail to pass the HTML/1. and Content-Type availability checks.

```go
// on line 82
if bytes.Contains(data, []byte("HTTP/1.")) && bytes.Contains(data, []byte("Content-Type: text/html")) { ... }
```